### PR TITLE
Track: Track1; Team name: weeyev; Model: HyMN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-08-02_13-03-24/results.json
+++ b/2026_tdl_challenge/outputs/2026-08-02_13-03-24/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-08-02_13-03-24",
+    "model_config": "graph/hymn",
+    "generated_at_utc": "2026-08-02T13:50:21.507574+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.369328498840332,
+      "test_best_rerun_accuracy": 0.2861563265323639,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2682023048400879,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2562457025051117,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2845519185066223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3212621212005615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2974635064601898,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22602948546409607,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3241271376609802,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37348154187202454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37516236305236816,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3130491375923157,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3670257329940796,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.359060287475586,
+      "test_best_rerun_accuracy": 0.2872259020805359,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2630835175514221,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24879670143127441,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28737872838974,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32019251585006714,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29753991961479187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23107188940048218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3227519392967224,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3669111430644989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.375773549079895,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29967913031578064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3538849353790283,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.387441873550415,
+      "test_best_rerun_accuracy": 0.27859270572662354,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2620902955532074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24150049686431885,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2717549204826355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3016273081302643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.286576509475708,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.210176482796669,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31041333079338074,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35472533106803894,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35720834136009216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2925739288330078,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3306211233139038,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.468062162399292,
+      "test_best_rerun_accuracy": 0.2516616880893707,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21796928346157074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.0666208267211914,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17980746924877167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20341508090496063,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26434409618377686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.0708228275179863,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1185346469283104,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23363129794597626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27725571393966675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1415310502052307,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11964245140552521,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.424856662750244,
+      "test_best_rerun_accuracy": 0.25536710023880005,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21032927930355072,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.06555122882127762,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1659790724515915,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1922224760055542,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25685688853263855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.07479563355445862,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10493544489145279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2192680835723877,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2626633048057556,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13014745712280273,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10986324399709702,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.4341094493865967,
+      "test_best_rerun_accuracy": 0.25403010845184326,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21583008766174316,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.06807243078947067,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17510886490345,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1979524791240692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2633509039878845,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.07162503153085709,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11108564585447311,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2368018925189972,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2764917016029358,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14023225009441376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12266024947166443,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.301295757293701,
+      "test_best_rerun_accuracy": 0.3295515179634094,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26598671078681946,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24990449845790863,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3065551221370697,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31194132566452026,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27672091126441956,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3551073372364044,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36614716053009033,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39510276913642883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36629995703697205,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45427459478378296,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5112308263778687,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.304945707321167,
+      "test_best_rerun_accuracy": 0.33012452721595764,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2722897231578827,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2547559142112732,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30976393818855286,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31438612937927246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2797769010066986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34930095076560974,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36714035272598267,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3983497619628906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36656734347343445,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4536251723766327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5165405869483948,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.3244845867156982,
+      "test_best_rerun_accuracy": 0.3307739198207855,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26300710439682007,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2484910935163498,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31041333079338074,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30582931637763977,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26980671286582947,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3416227400302887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36645275354385376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3887997567653656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3579723536968231,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44896477460861206,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5149362087249756,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.319017171859741,
+      "test_best_rerun_accuracy": 0.3035373091697693,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2634654939174652,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2565512955188751,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17980746924877167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2843991219997406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28867751359939575,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17419207096099854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3034227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33531972765922546,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37688136100769043,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2852395176887512,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3356635272502899,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2953617572784424,
+      "test_best_rerun_accuracy": 0.30143633484840393,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2586905062198639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2544502913951874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17831766605377197,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27790510654449463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28229811787605286,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16880586743354797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3145389258861542,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34498435258865356,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37470394372940063,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28172510862350464,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33967453241348267,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2774415016174316,
+      "test_best_rerun_accuracy": 0.30307891964912415,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25616928935050964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24665750563144684,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17407746613025665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26774391531944275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15684926509857178,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30132171511650085,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31923753023147583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36263275146484375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.253418892621994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31900832056999207,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.2035024166107178,
+      "test_best_rerun_accuracy": 0.38857054710388184,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2529987096786499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22679349780082703,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26434409618377686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24432729184627533,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35449615120887756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3633585572242737,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40025976300239563,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5262815952301025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.515241801738739,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5277714133262634,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5641378164291382,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.283745288848877,
+      "test_best_rerun_accuracy": 0.3906715512275696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24982810020446777,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2240430861711502,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2456642985343933,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24004890024662018,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35159292817115784,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3494919538497925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39731836318969727,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5283825993537903,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.518259584903717,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5401864051818848,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5764382481575012,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0903825759887695,
+      "test_best_rerun_accuracy": 0.39242875576019287,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2518908977508545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22637328505516052,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.261822909116745,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24268469214439392,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35503095388412476,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.360493540763855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4045763611793518,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5139048099517822,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5180686116218567,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.507678210735321,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.560967206954956,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1885831356048584,
+      "test_best_rerun_accuracy": 0.3511345386505127,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2393994927406311,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23065169155597687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15352585911750793,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22790129482746124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3390633463859558,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19378867745399475,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3374207317829132,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44460996985435486,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4987775981426239,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33994194865226746,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4300175607204437,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.177767753601074,
+      "test_best_rerun_accuracy": 0.35335013270378113,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2437542974948883,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23256169259548187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16426005959510803,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.243334099650383,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34846052527427673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18523187935352325,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36916494369506836,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45564979314804077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5044311881065369,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3404385447502136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43739017844200134,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.179112195968628,
+      "test_best_rerun_accuracy": 0.35335013270378113,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23126289248466492,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22816869616508484,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13366185128688812,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2058216780424118,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32974252104759216,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16334326565265656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31652534008026123,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44269996881484985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5010696053504944,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3198869228363037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3851325511932373,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.040889263153076,
+      "test_best_rerun_accuracy": 0.45194438099861145,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2467339038848877,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2270226925611496,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3022003173828125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27618610858917236,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3811597526073456,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3310413360595703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4622201919555664,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5224997997283936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48957139253616333,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6267476677894592,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6704866886138916,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8406970500946045,
+      "test_best_rerun_accuracy": 0.457330584526062,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2456642985343933,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21911528706550598,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29914432764053345,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27630069851875305,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38005194067955017,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33054473996162415,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46011918783187866,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5235694050788879,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49067920446395874,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6271296739578247,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.667698085308075,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8906126022338867,
+      "test_best_rerun_accuracy": 0.4529757797718048,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24283750355243683,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21537168323993683,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3043777346611023,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27836352586746216,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36954694986343384,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3195813298225403,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46080678701400757,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5033615827560425,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4745588004589081,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6160898208618164,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6609748601913452,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8145322799682617,
+      "test_best_rerun_accuracy": 0.4567957818508148,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24161510169506073,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22194208204746246,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2677057087421417,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26132631301879883,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3679807484149933,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3315379321575165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.387997567653656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5124914050102234,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4937734007835388,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5477117896080017,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.640308678150177,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8154293298721313,
+      "test_best_rerun_accuracy": 0.46378639340400696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23932309448719025,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2199556827545166,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27141112089157104,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2619374990463257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3712659478187561,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3307357430458069,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4091603755950928,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5189090371131897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4927802085876465,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5754068493843079,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6558560729026794,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8361198902130127,
+      "test_best_rerun_accuracy": 0.46500879526138306,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23955228924751282,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22041408717632294,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2653754949569702,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2606005072593689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3761555552482605,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33478492498397827,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41236916184425354,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5213156342506409,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4974406063556671,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5796088576316833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6630376577377319,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5257980823516846,
+      "test_best_rerun_accuracy": 0.5569180250167847,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2346244901418686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21403469145298004,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2369546890258789,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23508289456367493,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3867751657962799,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3518221378326416,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3919321596622467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4144701659679413,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5408357977867126,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6131484508514404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6483688354492188,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2.2031264305114746,
+      "test_best_rerun_accuracy": 0.5595538020133972,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22981129586696625,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21094048023223877,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24512949585914612,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.231912299990654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38967835903167725,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.354801744222641,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3973565697669983,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40476736426353455,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5410650372505188,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6022232174873352,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6304148435592651,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5260288715362549,
+      "test_best_rerun_accuracy": 0.5615402460098267,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23336389660835266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21403469145298004,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23577049374580383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24146229028701782,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38807395100593567,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35610052943229675,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3976621627807617,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4216899573802948,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5406448245048523,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6178852319717407,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6557796597480774,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.519071102142334,
+      "test_best_rerun_accuracy": 0.5474061965942383,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22713729739189148,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20914508402347565,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21693788468837738,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23248529434204102,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37405455112457275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35759034752845764,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3086179196834564,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40396517515182495,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5348384380340576,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5103521943092346,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6203300356864929,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5488592386245728,
+      "test_best_rerun_accuracy": 0.5458018183708191,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2312246859073639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21365268528461456,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21403469145298004,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2377568930387497,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3753533363342285,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3570173382759094,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30433952808380127,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.418442964553833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5360226035118103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4907555878162384,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6031400561332703,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5695936679840088,
+      "test_best_rerun_accuracy": 0.5421727895736694,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2240430861711502,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20643287897109985,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2078462839126587,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2287798970937729,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36778974533081055,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35212773084640503,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3213385343551636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40190234780311584,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5280005931854248,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.503055989742279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5985560417175293,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1462608575820923,
+      "test_best_rerun_accuracy": 0.6627320647239685,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23332569003105164,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2099090814590454,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26980671286582947,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25620749592781067,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38765376806259155,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3392161428928375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45358699560165405,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4642829895019531,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5532126426696777,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5284590125083923,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7042936682701111,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.19313383102417,
+      "test_best_rerun_accuracy": 0.657727837562561,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2361524999141693,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21101687848567963,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2540683150291443,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2568187117576599,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3874627649784088,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34716174006462097,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4373137652873993,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4553059935569763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5626479983329773,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5363281965255737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6941325068473816,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2017534971237183,
+      "test_best_rerun_accuracy": 0.6586446762084961,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23019328713417053,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20834288001060486,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25609290599823,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2512415051460266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38272595405578613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3383375406265259,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4428909718990326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4541599750518799,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5544732213020325,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5226144194602966,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6979143023490906,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.04792320728302,
+      "test_best_rerun_accuracy": 0.6947436928749084,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23034609854221344,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21216288208961487,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23813889920711517,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23603789508342743,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3735961616039276,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3458629250526428,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4052639603614807,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44136297702789307,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5430132150650024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5338070392608643,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6352662444114685,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0310757160186768,
+      "test_best_rerun_accuracy": 0.6953548789024353,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2309572994709015,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21468408405780792,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23943769931793213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24448010325431824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37814193964004517,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3477347493171692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40900754928588867,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45114219188690186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5459927916526794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.535869836807251,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6373290419578552,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0724622011184692,
+      "test_best_rerun_accuracy": 0.6987164616584778,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22977308928966522,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21094048023223877,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2468867003917694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24474750459194183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38081595301628113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3484223484992981,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41320955753326416,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.447780579328537,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5523722171783447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.538849413394928,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6460386514663696,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 17.205707550048828,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17.627193450927734,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.012699707097210184,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4711641073226929,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0077429689859089094
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11156121.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 846.1221843003412
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152.42501831054688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05137344735778459
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3868910.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 516.8884435537742
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43.7836799621582,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0378097408999639
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 570630930432.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 13250764.685862903
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 701197.4375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 49.16543524751087
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2486387456.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 127448.22676713312
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4790.5732421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8516574652777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3119123093520384.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 35283000503.60716
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229912592384.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3825946.3229327877
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 11.393843650817871,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11.480210304260254,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.008271044887795571,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4582054615020752,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.007674765586853027
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3617176.25,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 274.3402540766022
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 198.84962463378906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06702043297397677
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1100826.75,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 147.07104208416834
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.50063705444336,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03497464339761948
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 727787700224.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 16900141.65483931
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84688.65625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.93806312228299
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2503349504.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 128317.67409913373
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 792.2649536132812,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.14084710286458332
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2835060399013888.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 32069730654.09418
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291409788928.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4849313.379728088
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 8.719587326049805,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9.163252830505371,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.006601767168951996,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.6316769123077393,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.008587773222672311
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 876163.0625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 66.45150265453167
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.3227310180664,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03448693327201429
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197761.546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 26.421048346693386
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.71104049682617,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0403376860939777
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29781735424.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 691569.1859557867
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22637.689453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.5872731351230542
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161740368.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 8290.55143779794
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1086.111572265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1930865017361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71368565587968.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 807309317.4209925
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12277213184.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 204303.5492320237
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.4862087368965149,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.4986870288848877,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.002624668573078356,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98573896.0,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 71018.65706051873
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8696195710976.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 659552196.5093668
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43638.421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 14.707927831142568
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2167923408896.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 289635725.9714095
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28691.8671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 24.777087381260795
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.4229803738320077e+17,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 5626463806966.394
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 534381559808.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 37468907.5731314
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1078606142898176.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 55287618171.00702
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9683894272.0,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1721581.2039111112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.360537869641092e+21,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.539017759172304e+16
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.690518243613082e+16,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1612586864295.855
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.5750507116317749,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.5947498679161072,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0031302624627163535,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 833954.125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 600.8315021613832
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 646103236608.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 49002900.00819112
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2312.7685546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7794973221056622
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182287581184.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 24353718.261055443
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1270.3167724609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.096992031486129
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.440804816014541e+16,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 798997960248.593
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25705744384.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1802394.0810545506
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156968085880832.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 8045931922.744989
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163796032.0,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 29119.29457777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.3429303080260731e+20,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1519100378975909.2
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4012128939737088e+16,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 233174062532.02682
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.6479587554931641,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.6157007813453674,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0032405304281335127,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2917728.75,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2102.1100504322767
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1301369454592.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 98700754.99370497
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5247.63623046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7686674184255982
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 314132365312.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 41968251.87869071
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2975.186767578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.5692459132799006
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.030753792851968e+16,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 935991499361.8726
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52057567232.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3650088.853737204
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210140653420544.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 10771472316.39469
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 433459360.0,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 77059.44177777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4991786508949022e+20,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1695845899907132.2
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.6522042329268224e+16,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 274941213273.8959
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 596.1370849609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 608.6170654296875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.046159807768652826,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 388.0215148925781,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.27955440554220323
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 590.4876098632812,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.107829525596217
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.69721984863281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03090570267901342
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1448.4825439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.19351804194326153
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434.6385803222656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.375335561590903
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247946176.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 5757.620657625859
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3267.830078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.22912845871020895
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 782145.1875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 40.091505843456865
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1379.8067626953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.24529898003472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1106725568512.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 12519095.149621619
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98371792.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1636.9925282478825
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 376.7422790527344,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 390.05633544921875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.02958333981412353,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 762.8905639648438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5496329711562274
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1017.6470947265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.356037340666118
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.154541015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04690075531365858
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1540.909423828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.20586632248872747
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 780.048583984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.673617084615177
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 591731968.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 13740.757198588148
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3657.91455078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.2564797749811562
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1096527.75,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 56.20625096109488
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1478.0029296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.26275607638888887
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4369498505216.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 49427038.7341606
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224772576.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3740.4119614597375
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 315.558349609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 330.031494140625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.025030830044795224,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743.9174194335938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5359635586697361
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1016.877197265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.351985248766447
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.1375732421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04790615882783535
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1238.4334716796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1654553736379008
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 775.5984497070312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6697741361891462
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95812840.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2224.89411109047
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3385.59375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.23738562263357174
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 831719.375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 42.63259905684556
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1367.1181640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.24304322916666668
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11027227648.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 124738.16101263532
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43238096.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 719.5196778326927
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 26.90804672241211,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 25.747209548950195,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.008677859639012537,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.61837768554688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07393254876480322
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76.4493637084961,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.40236507214997946
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 768746432.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 58304.62131209708
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211388112.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 28241.564729458918
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.70990753173828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05847142273897952
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132449988247552.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3075654566.402378
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21211308.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1487.260412284392
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 397226409984.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 20361187.656158697
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71821.375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 12.768244444444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.744058634423501e+17,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 9891133371518.502
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51861503606784.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 863020711.3438171
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 24.197284698486328,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 23.10663414001465,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0077878780384275864,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 318.9475402832031,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.22978929415216365
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43.391544342041016,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.22837654916863692
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10138409984.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 768935.1523701176
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3355439616.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 448288.5258517034
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66.263671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05722251457253886
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1313047469621248.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 30490606298.096973
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 347981728.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 24399.22367129435
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4893702619136.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 250843334.8267979
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1086926.75,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 193.23142222222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.000443971099165e+18,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 67876021980013.85
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 527444129873920.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 8777130944.93402
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 20.3663330078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 19.78475570678711,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.006668269533800846,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1794.123291015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.2925960309910842
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.450400352478027,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07605473869725278
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158220156928.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 12000011.90200986
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57295663104.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7654731.209619238
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.88031768798828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06466348677719196
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.972358289240883e+16,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 458006290460.91473
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6346860544.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 445018.96956948534
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76146280497152.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3903136014.0013328
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19873148.0,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3533.004088888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.256842382216423e+19,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 934000246848684.2
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7982166654844928.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 132830224066.77863
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 305.7760925292969,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 306.7416687011719,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.04098085086188001,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196.2833709716797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1414145324003456
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.16901397705078,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1640474419844778
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27025.75,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.049734546833523
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1522.7427978515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5132264232731926
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36.545021057128906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03155874011841874
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255897328.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 5942.256362623073
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 825.5964965820312,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.05788784858940059
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 700690.5,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 35.91626941411656
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 492.2736511230469,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08751531575520834
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1746555895808.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 19756749.157924503
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99001928.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1647.478541593863
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2534.83642578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2678.3798828125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.3578329836756847,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191.6673583984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13808887492682817
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87.91374206542969,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.46270390560752467
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53354.3984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.046598288775123
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 795.8165893554688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.26822264555290487
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.00311279296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05440683315454987
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 602130432.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 13982.22255248003
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 538.8101196289062,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.037779422214900174
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3506151.75,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 179.71970628940488
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 467.22979736328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08306307508680555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1454787264512.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 16456311.035960319
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245889520.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4091.8163513221175
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 6251.9794921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6658.12109375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.889528536239145,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266.7766418457031,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1922021915314864
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.7023811340332,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.25106516386333266
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66969.34375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.07920695866515
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2184.794677734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.736364906550177
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39.124534606933594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03378629931514127
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1785731712.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 41466.92624930336
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1619.520751953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.11355495386012655
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10162155.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 520.895740427495
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 358.2092590332031,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.06368164605034722
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2743501848576.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 31034035.593543205
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742109376.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 12349.348110428835
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 25.959392547607422,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18.743398666381836,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.016186009211037855,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1636.8824462890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1793101198048002
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.102797031402588,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.032119984375803094
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63522914304.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4817816.784527873
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 872.771240234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.29415950125863666
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9891396608.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1321495.8728122911
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2886059645992960.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 67017918586.12669
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1031794880.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 72345.73552096481
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11811716857856.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 605449631.3422523
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3687756.75,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 655.6012
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.1168973255367197e+19,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 126341563695431.11
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1127175243694080.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 18757180431.898556
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 21.103042602539062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 19.572229385375977,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.016901752491689098,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6139.99853515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.423630068556376
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.175290584564209,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.021975213602969522
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138364747776.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 10494102.978839591
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 558.185546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.18813129318335017
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18046722048.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2411051.709819639
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4892629175107584.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 113612975457.63478
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1858189184.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 130289.52348899172
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20756308164608.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1063935012.7945051
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7246394.0,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1288.247822222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.6711358483311624e+19,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 189036101527229.0
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1891240664629248.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 31471896304.548748
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 25.23684310913086,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20.6436824798584,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.017827014231311226,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1607.765380859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1583324069592038
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.96476411819458,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03139349535891884
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36384813056.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2759561.0963974213
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1239.8792724609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.4178898794947548
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6179963392.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 825646.411756847
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1694699337285632.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 39353040527.71763
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 662902400.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 46480.325340064504
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7084572672000.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 363143814.2395817
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2471878.25,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 439.44502222222224
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.429731793489887e+18,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 72732054268405.9
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 666506849419264.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 11091256043.453712
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 8716.5869140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7471.1298828125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.1734889904052689,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 525.2785034179688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.378442725805453
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 341.32861328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7964663856907894
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5670.18505859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4300481652327455
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3190.549072265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.0753451541171637
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1067.14697265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.14257140583249833
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 295.33905029296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.25504235776594886
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1551.2996826171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.10877153853717483
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9102.443359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.46657662409016354
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 896.5093994140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1593794487847222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1031488.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 11.668020316052623
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40569.66796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6751147050197195
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 9905.9296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8883.04296875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.20627538010287014,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1391.6185302734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0026070102834563
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1028.6275634765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.413829281455592
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6037.322265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4578932321293136
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1513.9254150390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5102546056754508
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1538.26708984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.20551330525634603
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 889.7889404296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.768384231804566
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1464.2681884765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.10266920407211909
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8888.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4556200423522477
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1307.2794189453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.23240523003472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139294.296875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.5756738671198942
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45943.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7645430832210074
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 21015.72265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 13930.69140625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.32348809693131153,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 689.5216064453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.49677349167529716
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 565.9845581054688,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.9788660952919406
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9168.2568359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6953550880498672
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2500.349853515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.842719869739004
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 949.7711181640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.12688992894643453
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 457.5000915527344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.39507779926833714
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1261.5318603515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.08845406397080091
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7842.61669921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.40199993332404277
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 805.7711181640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.14324819878472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2400802.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 27.15747485945047
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37437.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6229986749704625
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 523.9093627929688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 537.657470703125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.03769860262958386,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 884.6560668945312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6373602787424577
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236.342529296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.243908048930921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41262.8671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.1295310722411833
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 731.354248046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.24649620763292046
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 613.3329467773438,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.08194160945589095
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191.4521026611328,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1653299677557278
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3113694.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 72.30387911016162
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4208.4404296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.21571789582692602
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 611.5632934570312,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10872236328125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25112692736.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 284070.59416535636
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1108490.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 18.446252059308073
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 665.1717529296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 675.8002319335938,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.04738467479551211,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1273.5635986328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.917553024951594
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 426.7116394042969,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.245850733706826
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35867.48046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.7203246468524838
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 761.513427734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.256661081137302
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 934.5150756835938,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1248517135181822
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 345.0239562988281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.29794814879000703
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20610.810546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4786088274864156
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12439.60546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6376341928725203
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744.4218139648438,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1323416558159722
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80345216.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 908.851690553488
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43232.41796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.719425190433994
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 680.9483642578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 692.1259765625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.04852937712540317,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1134.8404541015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8176083963267742
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 402.9716491699219,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.1209034166837992
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31606.23046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.3971354166666665
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 959.2816772460938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.32331704659457156
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 966.4822998046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.12912255174411322
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 316.2107849121094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2730663082142568
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7528496.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 174.8211034738993
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10814.537109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5543357993426111
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 679.2671508789062,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.12075860460069444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56034332672.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 633851.0307568748
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2773517.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 46.153753348975755
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2700.021728515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2817.09326171875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.1443996751098852,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2263.389892578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.630684360647064
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 575.39990234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.0284205386513157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81486.546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.180246255214259
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15695.6669921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.290079876032188
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1413.329833984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.18882162110679693
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 653.1290283203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5640147049398209
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47939.25390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.113209499959363
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12062.9560546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8458109700383887
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 690.9539184570312,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.12283625217013888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78179248.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 884.3506215852403
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12379.7783203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2060103226717338
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2717.21435546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2812.041259765625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.14414071760549618,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2090.747802734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.5063024515377341
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229.9859619140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2104524311266447
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113315.5859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.594280313803564
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15231.1767578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.133527724237445
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1879.071044921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.25104489578114564
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 320.3427734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.27663451937607947
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176141.671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.090230166148059
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15439.6484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0825724609101108
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 563.7310180664062,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10021884765625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 334311520.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3781.6761874597014
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39741.38671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6613313816709101
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 3961.48876953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4161.61083984375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.2133174862803706,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1700.9219970703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.225448124690427
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204.24891662597656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.0749942980314555
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100491.3359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.621640950891164
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10576.9091796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.5648497403732726
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1324.467041015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1769495044777054
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233.35916137695312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2015191376312203
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84992.9140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9736418833015976
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9872.771484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6922431274978965
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 360.92376708984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.06416422526041667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 818429.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 9.257940906982794
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32392.70703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5390429339731749
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 391.6265869140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 413.18621826171875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.07345532769097222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 606.4306030273438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.43690965635975776
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.25022888183594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5381590993780839
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37426.33203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.8385538135191504
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6730.0400390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.2682979572168858
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 426.6300964355469,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.05699800887582457
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104.21186065673828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08999297120616431
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 615358080.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 14289.38510124466
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2956.9892578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.20733342152660916
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1710614.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 87.6833256445743
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3390579933184.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 38353675.02442225
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233413920.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3884.211472218062
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 377.83026123046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 396.5664978027344,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.07050071072048611,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 750.5679931640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5407550383026387
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.25506591796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7487108732524671
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27949.65234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.1198067761660977
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8903.583984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.0008709081142566
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2856.760986328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.38166479443261525
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153.77090454101562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13279007300605838
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2179281.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 50.60565089169608
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5074.61474609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3558136829402433
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5440.0126953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.2788463117183095
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9915034624.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 112157.21891791002
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713232.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 11.86881791556421
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 343.17303466796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 355.1787414550781,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.06314288736979166,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 690.7764892578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4976775859206142
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.124412536621094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.26381269756116366
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38619.69140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9290626777588167
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6079.970703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.0491980799207954
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 590.6124267578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0789061358393871
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61.653175354003906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05324108407081512
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 445512800.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 10345.365038082853
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3375.49609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.23667761139741972
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1989526.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 101.97990670972372
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1176840044544.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 13312218.415031165
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179576752.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2988.3139799976702
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 132931.109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 72446.75,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.8195055597660713,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8828.7080078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.360740639634366
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3697.155517578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 19.458713250411183
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176201.328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 13.363771568069776
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36623.1640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 12.343499852544658
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8567.865234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.144671373997996
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4270.056640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.687440967724525
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115910.7890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6915936527610067
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42334.62890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.9683514869057634
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6061.6689453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3107114124410528
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4902.408203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8715392361111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29881.73046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.49725809110462116
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 32530.87109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 31383.919921875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.35500967073374207,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4632.66064453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.3376517611896612
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1552.016845703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.168509714226973
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120939.9453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.17254041050436
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21213.048828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 7.149662564248399
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3939.48828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5263177396459586
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1729.760009765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.4937478495385363
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70245.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6311848353613227
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22799.03125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.5985858399943906
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4190.64990234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.21480598197466555
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1876.48193359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.33359678819444444
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18976.365234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.31578328980704906
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 62558.6796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 44522.00390625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.5036254867623271,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5415.02783203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.9013168818668946
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2567.5419921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 13.51337890625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111981.8515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.493124881494122
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22120.96875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 7.455668604651163
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4335.4423828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5792174192134268
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2719.733642578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.3486473597393136
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60832.38671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4126041872271502
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21408.755859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.501104744031342
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4599.6474609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.23577053979893894
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2623.88232421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.46646796875
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16578.37109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2758785731075167
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 13901.466796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 14627.98046875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.2434223698059674,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8161.341796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.87992924846902
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4177.853515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 21.98870271381579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105601.296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.009199611300721
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13673.2900390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.608456366384395
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6004.77392578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8022410054483968
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4205.60693359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.631784916747625
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46498.98046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0797645473887703
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13253.1357421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9292620770009465
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4769.47412109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.24447558158253882
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3457.195068359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6146124565972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55166.64453125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.6240358871446671
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 12152.1123046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12678.8251953125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.21098672383326678,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9586.70703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.906849446145533
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5590.1240234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 29.421705386513157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102319.453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.76029223549488
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13495.38671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.5484956921975055
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7030.37939453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9392624441591516
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5467.880859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.721831484779793
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46788.16015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0864796618114898
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12257.5673828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8594564144448534
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4804.630859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.24627765950971348
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4373.92724609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7775870659722223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96434.171875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.0908472775245184
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hymn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 12017.615234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12594.6748046875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.20958638784363404,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12124.26171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.735058875180115
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7799.87353515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 41.05196597450658
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107360.171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.142599307925673
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11975.6162109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.036271051883215
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9075.7158203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2125204836756847
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7499.32177734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.4760982533193
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50467.22265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1719120995785344
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10879.400390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7628243157078249
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5888.3291015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.30182629051014914
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5815.607421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.033885763888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 974160.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 11.019537657093085
+        }
+      },
+      "output_dir": "/root/topobench-hymn/logs/train/runs/notebook_gu_grid_2026-08-02_13-03-24__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -104,7 +104,7 @@
    "outputs": [],
    "source": [
     "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-    "MODEL_CONFIG = \"graph/gin\""
+    "MODEL_CONFIG = \"graph/hymn\""
    ]
   },
   {

--- a/configs/model/graph/hymn.yaml
+++ b/configs/model/graph/hymn.yaml
@@ -1,0 +1,52 @@
+_target_: topobench.model.TBModel
+
+model_name: hymn
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  # The reference model reserves 16 channels for the encoded CSE.
+  out_channels: 48
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.HyMN
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: 64
+  # Published MolHIV HyMN (GIN, T=2) settings, translated to TopoBench.
+  num_layers: 2
+  num_samples: 3
+  cse_steps: 16
+  cse_channels: 16
+  dropout: 0.0
+  train_eps: true
+  batch_norm: true
+  residual: true
+  use_centrality_encoding: true
+  sample_aggregation: mean
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: 64
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: MLPReadout
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  in_channels: 64
+  hidden_layers: [64]
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+  dropout: 0.0
+  act: relu
+  norm: null
+  final_act: null
+
+compile: false

--- a/configs/model/graph/hymn.yaml
+++ b/configs/model/graph/hymn.yaml
@@ -7,31 +7,37 @@ feature_encoder:
   _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
   encoder_name: AllCellFeatureEncoder
   in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
-  # The reference model reserves 16 channels for the encoded CSE.
-  out_channels: 48
+  # The MolHIV reference config uses dim_inner=300 and reserves 16
+  # channels for the encoded CSE, leaving 284 node-feature channels.
+  out_channels: 284
   proj_dropout: 0.0
 
 backbone:
   _target_: topobench.nn.backbones.HyMN
   in_channels: ${model.feature_encoder.out_channels}
-  hidden_channels: 64
-  # Published MolHIV HyMN (GIN, T=2) settings, translated to TopoBench.
+  hidden_channels: 300
+  # Published MolHIV HyMN hyperparameters (Table 18 / with-CSE config),
+  # paired with the authors' edge-less marked-GIN path for unattributed graphs.
   num_layers: 2
+  # Two centrality-marked views plus the augmented policy's unmarked view.
   num_samples: 3
   cse_steps: 16
   cse_channels: 16
   dropout: 0.0
   train_eps: true
+  # Internal shared-MLP BN; the reference's separate between-layer BN is off.
   batch_norm: true
   residual: true
   use_centrality_encoding: true
   sample_aggregation: mean
+  # Semantic-only reuse of reference-style preprocessing across model instances.
+  global_cache_size: 65536
 
 backbone_wrapper:
   _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
   _partial_: true
   wrapper_name: GNNWrapper
-  out_channels: 64
+  out_channels: 300
   residual_connections: false
   num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
 
@@ -39,11 +45,12 @@ readout:
   _target_: topobench.nn.readouts.${model.readout.readout_name}
   readout_name: MLPReadout
   num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
-  in_channels: 64
-  hidden_layers: [64]
+  in_channels: 300
+  # layers_post_mp=1 in the reference config is a single linear head.
+  hidden_layers: []
   out_channels: ${dataset.parameters.num_classes}
   task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
-  pooling_type: sum
+  pooling_type: mean
   dropout: 0.0
   act: relu
   norm: null

--- a/docs/api/topobench.nn.backbones.graph.hymn.rst
+++ b/docs/api/topobench.nn.backbones.graph.hymn.rst
@@ -1,0 +1,7 @@
+topobench.nn.backbones.graph.hymn module
+========================================
+
+.. automodule:: topobench.nn.backbones.graph.hymn
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/topobench.nn.backbones.graph.rst
+++ b/docs/api/topobench.nn.backbones.graph.rst
@@ -22,5 +22,6 @@ Submodules
 
    topobench.nn.backbones.graph.gps
    topobench.nn.backbones.graph.graph_mlp
+   topobench.nn.backbones.graph.hymn
    topobench.nn.backbones.graph.identity_gnn
    topobench.nn.backbones.graph.nsd

--- a/test/nn/backbones/graph/test_hymn.py
+++ b/test/nn/backbones/graph/test_hymn.py
@@ -1,0 +1,313 @@
+"""Tests for the paper-faithful HyMN graph backbone."""
+
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.hymn import HyMN
+
+
+def _graph(edge_pairs, num_nodes, feature_dim=5):
+    """Create a simple undirected PyG graph."""
+    directed_edges = []
+    for source, target in edge_pairs:
+        directed_edges.extend([(source, target), (target, source)])
+    edge_index = torch.tensor(directed_edges, dtype=torch.long)
+    if directed_edges:
+        edge_index = edge_index.t().contiguous()
+    else:
+        edge_index = torch.empty((2, 0), dtype=torch.long)
+    return Data(x=torch.randn(num_nodes, feature_dim), edge_index=edge_index)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"in_channels": 0, "hidden_channels": 8}, "positive"),
+        ({"in_channels": 5, "hidden_channels": 0}, "positive"),
+        (
+            {"in_channels": 5, "hidden_channels": 8, "num_layers": 0},
+            "num_layers",
+        ),
+        (
+            {"in_channels": 5, "hidden_channels": 8, "num_samples": 0},
+            "num_samples",
+        ),
+        (
+            {"in_channels": 5, "hidden_channels": 8, "cse_steps": 0},
+            "cse_steps",
+        ),
+        ({"in_channels": 5, "hidden_channels": 8, "dropout": 1.1}, "dropout"),
+        (
+            {
+                "in_channels": 5,
+                "hidden_channels": 8,
+                "sample_aggregation": "max",
+            },
+            "sample_aggregation",
+        ),
+        (
+            {"in_channels": 5, "hidden_channels": 8, "cache_size": -1},
+            "cache_size",
+        ),
+        (
+            {"in_channels": 5, "hidden_channels": 8, "cse_channels": 8},
+            "cse_channels",
+        ),
+    ],
+)
+def test_hymn_rejects_invalid_configuration(kwargs, message):
+    """Every constructor constraint raises a useful error."""
+    with pytest.raises(ValueError, match=message):
+        HyMN(**kwargs)
+
+
+def test_hymn_graph_key_is_edge_order_independent():
+    """The cache key preserves graph structure but ignores COO ordering."""
+    edge_index = torch.tensor([[0, 1, 1], [1, 0, 2]])
+    reordered = edge_index[:, torch.tensor([2, 0, 1])]
+
+    assert HyMN._graph_key(3, edge_index) == HyMN._graph_key(3, reordered)
+    assert HyMN._graph_key(4, edge_index) != HyMN._graph_key(3, edge_index)
+    assert HyMN._graph_key(0, torch.empty((2, 0), dtype=torch.long)) == (
+        0,
+        b"",
+    )
+
+
+def test_hymn_cse_and_selection_match_equation_four():
+    """CSE columns equal diag(A^k)/k! and rank the top-SC node first."""
+    graph = _graph(
+        [(0, 1), (1, 2), (2, 0), (0, 3), (3, 4), (4, 0)],
+        5,
+    )
+    roots, cse = HyMN._compute_graph_statistics(
+        graph.num_nodes,
+        graph.edge_index,
+        num_marked_views=2,
+        cse_steps=3,
+    )
+
+    assert roots[0] == 0
+    torch.testing.assert_close(cse[:, 0], torch.zeros(5))
+    torch.testing.assert_close(
+        cse[:, 1], torch.tensor([2.0, 1.0, 1.0, 1.0, 1.0])
+    )
+    assert cse[0, 2] == pytest.approx(2 / 3)
+    assert cse[1, 2] == pytest.approx(1 / 3)
+
+
+def test_hymn_statistics_handle_empty_and_oversampled_graphs():
+    """Algorithm 1 statistics cover empty graphs and the reference T>|V| rule."""
+    empty_roots, empty_cse = HyMN._compute_graph_statistics(
+        0,
+        torch.empty((2, 0), dtype=torch.long),
+        num_marked_views=2,
+        cse_steps=3,
+    )
+    roots, cse = HyMN._compute_graph_statistics(
+        1,
+        torch.empty((2, 0), dtype=torch.long),
+        num_marked_views=3,
+        cse_steps=2,
+    )
+
+    assert empty_roots == ()
+    assert empty_cse.shape == (0, 3)
+    assert roots == (0, 0, 0)
+    torch.testing.assert_close(cse, torch.zeros((1, 2)))
+    with pytest.raises(ValueError, match="num_nodes"):
+        HyMN._compute_graph_statistics(-1, torch.empty((2, 0)), 1)
+    with pytest.raises(ValueError, match="num_marked_views"):
+        HyMN._compute_graph_statistics(1, torch.empty((2, 0)), -1)
+
+
+def test_hymn_batch_statistics_mark_roots_and_use_lru_cache():
+    """Batched preprocessing is graph-local and reuses cached CSEs."""
+    first = _graph([(0, 1), (1, 2), (2, 0)], 3)
+    second = _graph([(0, 1)], 2)
+    batched = Batch.from_data_list([first, second])
+    model = HyMN(
+        5, 8, num_samples=2, cse_steps=3, cse_channels=2, cache_size=2
+    )
+
+    markers, cse = model._statistics_for_batch(
+        batched.edge_index,
+        batched.batch,
+        batched.num_nodes,
+    )
+    cached_markers, cached_cse = model._statistics_for_batch(
+        batched.edge_index,
+        batched.batch,
+        batched.num_nodes,
+    )
+
+    assert markers.shape == (5, 2)
+    assert markers[:, 0].sum() == 0
+    assert markers[:3, 1].sum() == 1
+    assert markers[3:, 1].sum() == 1
+    assert cse.shape == (5, 3)
+    assert len(model._statistics_cache) == 2
+    torch.testing.assert_close(markers, cached_markers)
+    torch.testing.assert_close(cse, cached_cse)
+
+
+def test_hymn_batch_statistics_validate_assignments_and_skip_empty_ids():
+    """Batched CSE validates assignments and tolerates empty graph IDs."""
+    model = HyMN(5, 8, cse_steps=2, cse_channels=2, cache_size=0)
+    edge_index = torch.empty((2, 0), dtype=torch.long)
+    batch_with_gap = torch.tensor([0, 0, 2, 2])
+    markers, cse = model._statistics_for_batch(edge_index, batch_with_gap, 4)
+
+    assert markers.shape == (4, 3)
+    assert cse.shape == (4, 2)
+    assert not model._statistics_cache
+    with pytest.raises(ValueError, match="assign every node"):
+        model._statistics_for_batch(edge_index, torch.tensor([[0, 0]]), 2)
+    with pytest.raises(ValueError, match="negative"):
+        model._statistics_for_batch(edge_index, torch.tensor([-1, -1]), 2)
+    with pytest.raises(ValueError, match="grouped"):
+        model._statistics_for_batch(
+            edge_index,
+            torch.tensor([0, 1, 0, 1]),
+            4,
+        )
+
+
+def test_hymn_expand_views_offsets_edges_and_markers():
+    """The augmented bag is materialized as independent disjoint views."""
+    model = HyMN(2, 4, num_samples=2, cse_steps=2, cse_channels=2)
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    markers = torch.tensor([[0.0, 1.0], [0.0, 0.0]])
+
+    expanded_x, expanded_edges, expanded_markers = model._expand_views(
+        x,
+        edge_index,
+        markers,
+    )
+
+    torch.testing.assert_close(expanded_x, x.repeat(2, 1))
+    assert expanded_edges.tolist() == [[0, 1, 2, 3], [1, 0, 3, 2]]
+    assert expanded_markers.squeeze(-1).tolist() == [0.0, 0.0, 1.0, 0.0]
+
+
+def test_hymn_forward_and_gradients():
+    """HyMN returns node-aligned, finite, differentiable embeddings."""
+    graph = _graph([(0, 1), (1, 2), (2, 0), (2, 3)], 4)
+    model = HyMN(
+        5,
+        8,
+        num_layers=2,
+        num_samples=3,
+        cse_steps=3,
+        cse_channels=2,
+    )
+    output = model(graph.x, graph.edge_index)
+
+    assert output.shape == (4, 8)
+    assert torch.isfinite(output).all()
+    output.sum().backward()
+    assert all(
+        parameter.grad is not None
+        for parameter in model.parameters()
+        if parameter.requires_grad
+    )
+
+
+def test_hymn_supports_no_cse_no_norm_no_residual_and_sum():
+    """Paper-supported ablations and sum view pooling execute together."""
+    graph = _graph([(0, 1), (1, 2)], 3)
+    model = HyMN(
+        5,
+        8,
+        num_layers=1,
+        num_samples=2,
+        cse_steps=2,
+        batch_norm=False,
+        residual=False,
+        use_centrality_encoding=False,
+        sample_aggregation="sum",
+    )
+
+    output = model(graph.x, graph.edge_index)
+
+    assert model.cse_norm is None
+    assert model.cse_encoder is None
+    assert output.shape == (3, 8)
+
+
+def test_hymn_mean_and_sum_aggregation_are_consistent():
+    """Sum aggregation equals mean aggregation times the bag size."""
+    graph = _graph([(0, 1), (1, 2), (2, 0)], 3)
+    model = HyMN(5, 8, num_samples=3, cse_steps=3, cse_channels=2).eval()
+
+    mean_output = model(graph.x, graph.edge_index)
+    model.sample_aggregation = "sum"
+    sum_output = model(graph.x, graph.edge_index)
+
+    torch.testing.assert_close(sum_output, mean_output * model.num_samples)
+
+
+def test_hymn_is_deterministic_and_batch_local_in_eval_mode():
+    """Selection is deterministic and another graph cannot change outputs."""
+    first = _graph([(0, 1), (1, 2), (2, 0), (2, 3)], 4)
+    second = _graph([(0, 1), (1, 2), (2, 3)], 4)
+    model = HyMN(
+        5,
+        8,
+        num_layers=2,
+        num_samples=3,
+        cse_steps=3,
+        cse_channels=2,
+        dropout=0.2,
+    ).eval()
+
+    isolated = model(first.x, first.edge_index)
+    repeated = model(first.x, first.edge_index)
+    batched = Batch.from_data_list([first, second])
+    combined = model(batched.x, batched.edge_index, batch=batched.batch)
+
+    torch.testing.assert_close(isolated, repeated)
+    torch.testing.assert_close(isolated, combined[: first.num_nodes])
+
+
+def test_hymn_permutation_equivariance_with_unique_root():
+    """Relabelling an asymmetric graph relabels node embeddings."""
+    graph = _graph(
+        [(0, 1), (1, 2), (2, 0), (0, 3), (0, 4), (4, 5)],
+        6,
+    )
+    permutation = torch.tensor([3, 0, 5, 2, 1, 4])
+    inverse = torch.empty_like(permutation)
+    inverse[permutation] = torch.arange(permutation.numel())
+    permuted = Data(
+        x=graph.x[permutation],
+        edge_index=inverse[graph.edge_index],
+    )
+    model = HyMN(
+        5,
+        8,
+        num_layers=2,
+        num_samples=2,
+        cse_steps=4,
+        cse_channels=2,
+    ).eval()
+
+    original_output = model(graph.x, graph.edge_index)
+    permuted_output = model(permuted.x, permuted.edge_index)
+    torch.testing.assert_close(
+        original_output[permutation],
+        permuted_output,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+def test_hymn_forward_validates_tensor_shapes():
+    """Forward rejects malformed node and edge tensors."""
+    model = HyMN(5, 8, cse_steps=2, cse_channels=2)
+    with pytest.raises(ValueError, match="two-dimensional"):
+        model(torch.randn(5), torch.empty((2, 0), dtype=torch.long))
+    with pytest.raises(ValueError, match="edge_index"):
+        model(torch.randn(2, 5), torch.empty((3, 0), dtype=torch.long))

--- a/test/nn/backbones/graph/test_hymn.py
+++ b/test/nn/backbones/graph/test_hymn.py
@@ -4,7 +4,10 @@ import pytest
 import torch
 from torch_geometric.data import Batch, Data
 
-from topobench.nn.backbones.graph.hymn import HyMN
+from topobench.nn.backbones.graph.hymn import (
+    _GLOBAL_STATISTICS_CACHE,
+    HyMN,
+)
 
 
 def _graph(edge_pairs, num_nodes, feature_dim=5):
@@ -49,6 +52,14 @@ def _graph(edge_pairs, num_nodes, feature_dim=5):
         (
             {"in_channels": 5, "hidden_channels": 8, "cache_size": -1},
             "cache_size",
+        ),
+        (
+            {
+                "in_channels": 5,
+                "hidden_channels": 8,
+                "global_cache_size": -1,
+            },
+            "global_cache_size",
         ),
         (
             {"in_channels": 5, "hidden_channels": 8, "cse_channels": 8},
@@ -152,6 +163,57 @@ def test_hymn_batch_statistics_mark_roots_and_use_lru_cache():
     torch.testing.assert_close(cse, cached_cse)
 
 
+def test_hymn_global_cache_reuses_reference_preprocessing(monkeypatch):
+    """Independent models reuse the authors' deterministic preprocessing."""
+    graph = _graph([(0, 1), (1, 2), (2, 0)], 3)
+    batch = torch.zeros(graph.num_nodes, dtype=torch.long)
+    _GLOBAL_STATISTICS_CACHE.clear()
+    try:
+        first = HyMN(
+            5,
+            8,
+            num_samples=2,
+            cse_steps=3,
+            cse_channels=2,
+            cache_size=0,
+            global_cache_size=2,
+        )
+        expected = first._statistics_for_batch(
+            graph.edge_index,
+            batch,
+            graph.num_nodes,
+        )
+        assert len(_GLOBAL_STATISTICS_CACHE) == 1
+
+        def fail_if_recomputed(*args, **kwargs):
+            raise AssertionError("global cache entry was recomputed")
+
+        monkeypatch.setattr(
+            HyMN,
+            "_compute_graph_statistics",
+            staticmethod(fail_if_recomputed),
+        )
+        second = HyMN(
+            5,
+            8,
+            num_samples=2,
+            cse_steps=3,
+            cse_channels=2,
+            cache_size=0,
+            global_cache_size=2,
+        )
+        actual = second._statistics_for_batch(
+            graph.edge_index,
+            batch,
+            graph.num_nodes,
+        )
+
+        torch.testing.assert_close(actual[0], expected[0])
+        torch.testing.assert_close(actual[1], expected[1])
+    finally:
+        _GLOBAL_STATISTICS_CACHE.clear()
+
+
 def test_hymn_batch_statistics_validate_assignments_and_skip_empty_ids():
     """Batched CSE validates assignments and tolerates empty graph IDs."""
     model = HyMN(5, 8, cse_steps=2, cse_channels=2, cache_size=0)
@@ -190,6 +252,55 @@ def test_hymn_expand_views_offsets_edges_and_markers():
     torch.testing.assert_close(expanded_x, x.repeat(2, 1))
     assert expanded_edges.tolist() == [[0, 1, 2, 3], [1, 0, 3, 2]]
     assert expanded_markers.squeeze(-1).tolist() == [0.0, 0.0, 1.0, 0.0]
+
+
+def test_hymn_disjoint_views_match_authors_wide_tensor_update():
+    """Disjoint views exactly reproduce the authors' shared wide-tensor GIN."""
+    graph = _graph([(0, 1), (1, 2), (2, 0)], 3, feature_dim=4)
+    model = HyMN(
+        4,
+        4,
+        num_layers=2,
+        num_samples=3,
+        cse_steps=2,
+        use_centrality_encoding=False,
+        dropout=0.0,
+        residual=True,
+    ).eval()
+    markers = torch.tensor([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]])
+
+    disjoint, expanded_edges, expanded_markers = model._expand_views(
+        graph.x,
+        graph.edge_index,
+        markers,
+    )
+    reference = graph.x[:, None, :].expand(-1, model.num_samples, -1)
+    source, target = graph.edge_index
+
+    for conv in model.convs:
+        disjoint_input = torch.cat((disjoint, expanded_markers), dim=-1)
+        disjoint_update = torch.relu(conv(disjoint_input, expanded_edges))
+        disjoint = disjoint + disjoint_update
+
+        # The reference implementation stores all views in one wide tensor,
+        # aggregates each view independently, then applies one shared MLP.
+        reference_input = torch.cat((reference, markers.unsqueeze(-1)), dim=-1)
+        wide_input = reference_input.reshape(graph.num_nodes, -1)
+        wide_messages = torch.zeros_like(wide_input)
+        wide_messages.index_add_(0, target, wide_input[source])
+        wide_update = (1 + conv.eps) * wide_input + wide_messages
+        reference_update = torch.relu(
+            conv.nn(wide_update.reshape(-1, model.hidden_channels + 1))
+        ).reshape(graph.num_nodes, model.num_samples, model.hidden_channels)
+        reference = reference + reference_update
+
+    disjoint = disjoint.reshape(
+        model.num_samples,
+        graph.num_nodes,
+        model.hidden_channels,
+    ).permute(1, 0, 2)
+    torch.testing.assert_close(disjoint, reference)
+    torch.testing.assert_close(disjoint.mean(dim=1), reference.mean(dim=1))
 
 
 def test_hymn_forward_and_gradients():

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,13 +1,11 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
-import pytest
 
 from test._utils.simplified_pipeline import run
 
-
-DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+DATASET = "graph/MUTAG"
+MODELS = ["graph/hymn"]
 
 
 class TestPipeline:
@@ -34,6 +32,6 @@ class TestPipeline:
                         "paths=test",
                         "callbacks=model_checkpoint",
                     ],
-                    return_hydra_config=True
+                    return_hydra_config=True,
                 )
                 run(cfg)

--- a/topobench/nn/backbones/graph/hymn.py
+++ b/topobench/nn/backbones/graph/hymn.py
@@ -8,9 +8,11 @@ paper, and the authors' reference implementation [2].
 References
 ----------
 [1] J. Southern et al., "Balancing Efficiency and Expressiveness: Subgraph
-    GNNs with Walk-Based Centrality," ICML 2025.
-[2] https://github.com/jks17/HyMN (``graphgps/network/colour_gnn.py`` and
-    ``graphgps/transform/posenc_stats.py``).
+    GNNs with Walk-Based Centrality," ICML 2025,
+    https://proceedings.mlr.press/v267/southern25a.html.
+[2] J. Southern et al., HyMN reference implementation, revision
+    ``adde55268307ff69527375757ec31a146d59ccae``,
+    https://github.com/jks17/HyMN.
 """
 
 from __future__ import annotations
@@ -21,6 +23,13 @@ from collections import OrderedDict
 import torch
 from torch import nn
 from torch_geometric.nn import GINConv
+
+# The reference implementation computes CSEs once in the dataset transform.
+# TopoBench constructs a fresh backbone for every benchmark run, so a bounded
+# process cache preserves that preprocessing behavior across model instances.
+_GLOBAL_STATISTICS_CACHE: OrderedDict[
+    tuple[int, int, int, bytes], tuple[tuple[int, ...], torch.Tensor]
+] = OrderedDict()
 
 
 class HyMN(nn.Module):
@@ -76,6 +85,10 @@ class HyMN(nn.Module):
         in the reference configurations.
     cache_size : int, optional
         Maximum number of per-graph CSE computations retained by a model.
+    global_cache_size : int, optional
+        Maximum number of CSE computations shared across model instances in a
+        process.  This mirrors the reference implementation's dataset-level
+        preprocessing when TopoBench creates a model per benchmark run.
     **kwargs : dict, optional
         Extra configuration values accepted for TopoBench compatibility.
 
@@ -83,6 +96,22 @@ class HyMN(nn.Module):
     -----
     Node features are expected to be ordered graph-by-graph when ``batch`` is
     supplied, as they are in :class:`torch_geometric.data.Batch`.
+
+    The authors use marked GINE layers when molecular bond attributes are
+    available and marked GIN layers for unattributed counting graphs.  The
+    standard TopoBench :class:`~topobench.nn.wrappers.GNNWrapper` does not
+    expose bond attributes, so this backbone follows the latter, edge-less
+    reference path (``counting_substructures/conv.py`` in [2]).  It contains
+    no GraphUniverse-specific features, labels, or task logic.
+
+    Exact centrality ties are resolved by stable node-index order.  This is a
+    deterministic instance of the arbitrary tie-breaking policy explicitly
+    allowed by [1]; as with the authors' ``torch.argsort`` implementation,
+    tied selections need not be permutation equivariant.
+
+    Both statistics caches store only the deterministic output of Algorithm
+    1.  They reproduce the authors' dataset-level preprocessing without
+    changing the mathematical forward pass.
     """
 
     def __init__(
@@ -100,6 +129,7 @@ class HyMN(nn.Module):
         use_centrality_encoding: bool = True,
         sample_aggregation: str = "mean",
         cache_size: int = 4096,
+        global_cache_size: int = 65536,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -119,6 +149,8 @@ class HyMN(nn.Module):
             raise ValueError("sample_aggregation must be mean or sum")
         if cache_size < 0:
             raise ValueError("cache_size cannot be negative")
+        if global_cache_size < 0:
+            raise ValueError("global_cache_size cannot be negative")
         if use_centrality_encoding and not 0 < cse_channels < hidden_channels:
             raise ValueError(
                 "cse_channels must lie between zero and hidden_channels"
@@ -138,6 +170,7 @@ class HyMN(nn.Module):
         self.use_centrality_encoding = use_centrality_encoding
         self.sample_aggregation = sample_aggregation
         self.cache_size = cache_size
+        self.global_cache_size = global_cache_size
 
         node_channels = (
             hidden_channels - cse_channels
@@ -320,12 +353,28 @@ class HyMN(nn.Module):
             key = self._graph_key(graph_size, local_edges)
             cached = self._statistics_cache.get(key)
             if cached is None:
-                cached = self._compute_graph_statistics(
-                    graph_size,
-                    local_edges,
-                    self.num_samples - 1,
+                global_key = (
                     self.cse_steps,
+                    self.num_samples - 1,
+                    *key,
                 )
+                cached = _GLOBAL_STATISTICS_CACHE.get(global_key)
+                if cached is None:
+                    cached = self._compute_graph_statistics(
+                        graph_size,
+                        local_edges,
+                        self.num_samples - 1,
+                        self.cse_steps,
+                    )
+                    if self.global_cache_size:
+                        _GLOBAL_STATISTICS_CACHE[global_key] = cached
+                        if (
+                            len(_GLOBAL_STATISTICS_CACHE)
+                            > self.global_cache_size
+                        ):
+                            _GLOBAL_STATISTICS_CACHE.popitem(last=False)
+                elif self.global_cache_size:
+                    _GLOBAL_STATISTICS_CACHE.move_to_end(global_key)
                 if self.cache_size:
                     self._statistics_cache[key] = cached
                     if len(self._statistics_cache) > self.cache_size:

--- a/topobench/nn/backbones/graph/hymn.py
+++ b/topobench/nn/backbones/graph/hymn.py
@@ -1,0 +1,441 @@
+"""Hybrid Marking Network (HyMN) graph backbone.
+
+This module implements the centrality structural encodings, centrality-guided
+node marking, and shared message passing proposed by Southern et al. [1].  The
+implementation follows Algorithm 1 and Equations (4) and (45)--(48) of the
+paper, and the authors' reference implementation [2].
+
+References
+----------
+[1] J. Southern et al., "Balancing Efficiency and Expressiveness: Subgraph
+    GNNs with Walk-Based Centrality," ICML 2025.
+[2] https://github.com/jks17/HyMN (``graphgps/network/colour_gnn.py`` and
+    ``graphgps/transform/posenc_stats.py``).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import OrderedDict
+
+import torch
+from torch import nn
+from torch_geometric.nn import GINConv
+
+
+class HyMN(nn.Module):
+    r"""Centrality-guided Hybrid Marking Network.
+
+    For every input graph, HyMN computes the order-:math:`K` Centrality
+    Structural Encoding (CSE)
+
+    .. math::
+        C^{\mathrm{CSE}}_{v,k} = (A^k)_{vv} / k!,
+
+    selects the :math:`T` nodes with the largest truncated Subgraph Centrality,
+    and processes an unmarked view plus the :math:`T` marked views with shared
+    GIN layers.  These are Algorithm 1, Equation (4), and Equations (45)--(48)
+    in [1].  As in the reference implementation, the CSE is batch-normalized,
+    linearly encoded, and concatenated with the input node representation.
+
+    Views are represented as a disjoint expanded graph during message passing,
+    then reduced back to node-aligned embeddings before TopoBench's task
+    readout.  This is algebraically the same node-wise view aggregation used by
+    ``MeanAveraging``/``SumAveraging`` in [2], while satisfying TopoBench's
+    backbone API for both node- and graph-level tasks.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input node features after TopoBench's feature encoder.
+    hidden_channels : int
+        Width of the shared marked GIN and output node embeddings.
+    num_layers : int, optional
+        Number of shared GIN message-passing layers.
+    num_samples : int, optional
+        Total number of views.  Following the augmented policy in Equation
+        (45), this includes one unmarked view and ``num_samples - 1`` marked
+        views.
+    cse_steps : int, optional
+        Maximum walk length :math:`K` in Equation (4).
+    cse_channels : int, optional
+        Width of the linearly encoded CSE.
+    dropout : float, optional
+        Dropout after each marked GIN layer.
+    train_eps : bool, optional
+        Whether GIN's epsilon parameters are trainable.
+    batch_norm : bool, optional
+        Whether the two-layer GIN MLPs use Batch Normalization, as in [2].
+    residual : bool, optional
+        Whether to use the layer-wise residual connections reported in [1].
+    use_centrality_encoding : bool, optional
+        Whether to concatenate CSEs to node features.  Disabling this exposes
+        the paper's ``HyMN no CSE`` ablation without changing node selection.
+    sample_aggregation : str, optional
+        ``"mean"`` or ``"sum"`` aggregation over the augmented bag, both used
+        in the reference configurations.
+    cache_size : int, optional
+        Maximum number of per-graph CSE computations retained by a model.
+    **kwargs : dict, optional
+        Extra configuration values accepted for TopoBench compatibility.
+
+    Notes
+    -----
+    Node features are expected to be ordered graph-by-graph when ``batch`` is
+    supplied, as they are in :class:`torch_geometric.data.Batch`.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_layers: int = 2,
+        num_samples: int = 3,
+        cse_steps: int = 16,
+        cse_channels: int = 16,
+        dropout: float = 0.0,
+        train_eps: bool = True,
+        batch_norm: bool = True,
+        residual: bool = True,
+        use_centrality_encoding: bool = True,
+        sample_aggregation: str = "mean",
+        cache_size: int = 4096,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        if in_channels < 1 or hidden_channels < 1:
+            raise ValueError(
+                "in_channels and hidden_channels must be positive"
+            )
+        if num_layers < 1:
+            raise ValueError("num_layers must be positive")
+        if num_samples < 1:
+            raise ValueError("num_samples must include the unmarked view")
+        if cse_steps < 1:
+            raise ValueError("cse_steps must be positive")
+        if not 0.0 <= dropout <= 1.0:
+            raise ValueError("dropout must be between zero and one")
+        if sample_aggregation not in {"mean", "sum"}:
+            raise ValueError("sample_aggregation must be mean or sum")
+        if cache_size < 0:
+            raise ValueError("cache_size cannot be negative")
+        if use_centrality_encoding and not 0 < cse_channels < hidden_channels:
+            raise ValueError(
+                "cse_channels must lie between zero and hidden_channels"
+            )
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = hidden_channels
+        self.num_layers = num_layers
+        self.num_samples = num_samples
+        self.cse_steps = cse_steps
+        self.cse_channels = cse_channels
+        self.dropout = dropout
+        self.train_eps = train_eps
+        self.batch_norm = batch_norm
+        self.residual = residual
+        self.use_centrality_encoding = use_centrality_encoding
+        self.sample_aggregation = sample_aggregation
+        self.cache_size = cache_size
+
+        node_channels = (
+            hidden_channels - cse_channels
+            if use_centrality_encoding
+            else hidden_channels
+        )
+        self.node_encoder = (
+            nn.Identity()
+            if in_channels == node_channels
+            else nn.Linear(in_channels, node_channels)
+        )
+        if use_centrality_encoding:
+            self.cse_norm = nn.BatchNorm1d(cse_steps)
+            self.cse_encoder = nn.Linear(cse_steps, cse_channels)
+        else:
+            self.cse_norm = None
+            self.cse_encoder = None
+
+        self.convs = nn.ModuleList()
+        for _ in range(num_layers):
+            mlp = nn.Sequential(
+                nn.Linear(hidden_channels + 1, hidden_channels),
+                nn.BatchNorm1d(hidden_channels)
+                if batch_norm
+                else nn.Identity(),
+                nn.ReLU(),
+                nn.Linear(hidden_channels, hidden_channels),
+            )
+            self.convs.append(GINConv(mlp, train_eps=train_eps))
+        self.dropout_layer = nn.Dropout(dropout)
+        self._statistics_cache: OrderedDict[
+            tuple[int, bytes], tuple[tuple[int, ...], torch.Tensor]
+        ] = OrderedDict()
+
+    @staticmethod
+    def _graph_key(
+        num_nodes: int,
+        local_edge_index: torch.Tensor,
+    ) -> tuple[int, bytes]:
+        """Return an exact, edge-order-independent key for the CSE cache.
+
+        Parameters
+        ----------
+        num_nodes : int
+            Number of nodes in the graph.
+        local_edge_index : torch.Tensor
+            Local COO edge indices of shape ``[2, num_edges]``.
+
+        Returns
+        -------
+        tuple[int, bytes]
+            Node count and sorted linearized edge list.
+        """
+        if local_edge_index.numel() == 0:
+            return num_nodes, b""
+        linear_edges = local_edge_index[0].to(
+            torch.int64
+        ) * num_nodes + local_edge_index[1].to(torch.int64)
+        edge_bytes = torch.sort(linear_edges.cpu()).values.numpy().tobytes()
+        return num_nodes, edge_bytes
+
+    @staticmethod
+    def _compute_graph_statistics(
+        num_nodes: int,
+        local_edge_index: torch.Tensor,
+        num_marked_views: int,
+        cse_steps: int = 16,
+    ) -> tuple[tuple[int, ...], torch.Tensor]:
+        r"""Compute Algorithm 1's CSE and top-centrality marked nodes.
+
+        The returned columns are :math:`\operatorname{diag}(A^k)/k!` for
+        :math:`k=1,\ldots,K`, matching ``centrality_posenc`` in [2].  Their sum
+        is the paper's truncated estimate of Subgraph Centrality.
+
+        Parameters
+        ----------
+        num_nodes : int
+            Number of nodes in the graph.
+        local_edge_index : torch.Tensor
+            Local COO edge indices of shape ``[2, num_edges]``.
+        num_marked_views : int
+            Number :math:`T` of centrality-ranked nodes to mark.
+        cse_steps : int, optional
+            Maximum walk length :math:`K`.
+
+        Returns
+        -------
+        tuple[tuple[int, ...], torch.Tensor]
+            Selected local node indices and the ``[num_nodes, cse_steps]`` CSE.
+        """
+        if num_nodes < 0:
+            raise ValueError("num_nodes cannot be negative")
+        if num_marked_views < 0:
+            raise ValueError("num_marked_views cannot be negative")
+
+        adjacency = torch.zeros((num_nodes, num_nodes), dtype=torch.float32)
+        if local_edge_index.numel():
+            edges = local_edge_index.to(device="cpu", dtype=torch.long)
+            adjacency.index_put_(
+                (edges[0], edges[1]),
+                torch.ones(edges.size(1), dtype=adjacency.dtype),
+                accumulate=True,
+            )
+
+        encodings = []
+        adjacency_power = adjacency
+        for walk_length in range(1, cse_steps + 1):
+            encodings.append(
+                torch.diagonal(adjacency_power) / math.factorial(walk_length)
+            )
+            adjacency_power = adjacency_power @ adjacency
+        cse = torch.stack(encodings, dim=-1)
+
+        if num_nodes == 0:
+            roots: tuple[int, ...] = ()
+        else:
+            order = torch.argsort(-cse.sum(dim=-1), stable=True)
+            # The authors' implementation retains T views even when T > |V|,
+            # filling the remaining marks with node zero.
+            selected = torch.zeros(num_marked_views, dtype=torch.long)
+            available = min(num_nodes, num_marked_views)
+            selected[:available] = order[:available]
+            roots = tuple(int(index) for index in selected)
+        return roots, cse
+
+    def _statistics_for_batch(
+        self,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor,
+        num_nodes: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute or retrieve Algorithm 1 statistics for a PyG batch.
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            Batched COO edge indices.
+        batch : torch.Tensor
+            Graph assignment for every node.
+        num_nodes : int
+            Total number of nodes.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor]
+            Marker matrix ``[num_nodes, num_samples]`` and CSE matrix
+            ``[num_nodes, cse_steps]`` on ``edge_index.device``.
+        """
+        if batch.ndim != 1 or batch.numel() != num_nodes:
+            raise ValueError("batch must assign every node to one graph")
+        if batch.numel() and int(batch.min()) < 0:
+            raise ValueError("batch graph indices cannot be negative")
+
+        markers = torch.zeros(
+            (num_nodes, self.num_samples),
+            dtype=torch.float32,
+            device=edge_index.device,
+        )
+        cse = torch.zeros(
+            (num_nodes, self.cse_steps),
+            dtype=torch.float32,
+            device=edge_index.device,
+        )
+        num_graphs = int(batch.max()) + 1 if batch.numel() else 0
+        graph_sizes = (
+            torch.bincount(batch, minlength=num_graphs).cpu().tolist()
+        )
+
+        node_offset = 0
+        for graph_index, graph_size in enumerate(graph_sizes):
+            next_offset = node_offset + graph_size
+            if graph_size == 0:
+                node_offset = next_offset
+                continue
+            if not torch.all(batch[node_offset:next_offset] == graph_index):
+                raise ValueError("batch nodes must be grouped by graph")
+
+            edge_mask = batch[edge_index[0]] == graph_index
+            local_edges = (edge_index[:, edge_mask] - node_offset).cpu()
+            key = self._graph_key(graph_size, local_edges)
+            cached = self._statistics_cache.get(key)
+            if cached is None:
+                cached = self._compute_graph_statistics(
+                    graph_size,
+                    local_edges,
+                    self.num_samples - 1,
+                    self.cse_steps,
+                )
+                if self.cache_size:
+                    self._statistics_cache[key] = cached
+                    if len(self._statistics_cache) > self.cache_size:
+                        self._statistics_cache.popitem(last=False)
+            elif self.cache_size:
+                self._statistics_cache.move_to_end(key)
+
+            roots, graph_cse = cached
+            for sample_index, root in enumerate(roots, start=1):
+                markers[node_offset + root, sample_index] = 1.0
+            cse[node_offset:next_offset] = graph_cse.to(edge_index.device)
+            node_offset = next_offset
+        return markers, cse
+
+    def _expand_views(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        markers: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Materialize the augmented bag as one disjoint expanded graph.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features shared by every view.
+        edge_index : torch.Tensor
+            Original batched COO edge indices.
+        markers : torch.Tensor
+            Marker matrix with one column per view.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            Repeated features, view-offset edges, and flattened markers.
+        """
+        num_nodes = x.size(0)
+        expanded_x = x.repeat(self.num_samples, 1)
+        offsets = (
+            torch.arange(self.num_samples, device=edge_index.device)
+            * num_nodes
+        )
+        expanded_edges = edge_index.unsqueeze(0) + offsets[:, None, None]
+        expanded_edges = expanded_edges.permute(1, 0, 2).reshape(2, -1)
+        expanded_markers = markers.transpose(0, 1).reshape(-1, 1)
+        return expanded_x, expanded_edges, expanded_markers
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Encode the unmarked graph and its top-centrality marked views.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node feature matrix of shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            COO edge indices of shape ``[2, num_edges]``.
+        batch : torch.Tensor, optional
+            Graph assignment for each node.  A single graph is assumed when
+            omitted.
+        **kwargs : dict, optional
+            Extra wrapper arguments, such as unused edge weights.
+
+        Returns
+        -------
+        torch.Tensor
+            Node-aligned view-aggregated embeddings of shape
+            ``[num_nodes, hidden_channels]``.
+        """
+        if x.ndim != 2:
+            raise ValueError("x must be a two-dimensional node feature matrix")
+        if edge_index.ndim != 2 or edge_index.size(0) != 2:
+            raise ValueError("edge_index must have shape [2, num_edges]")
+        if batch is None:
+            batch = torch.zeros(x.size(0), dtype=torch.long, device=x.device)
+
+        with torch.no_grad():
+            markers, cse = self._statistics_for_batch(
+                edge_index,
+                batch,
+                x.size(0),
+            )
+
+        node_features = self.node_encoder(x)
+        if self.use_centrality_encoding:
+            cse = cse.to(dtype=x.dtype)
+            cse_features = self.cse_encoder(self.cse_norm(cse))
+            node_features = torch.cat((node_features, cse_features), dim=-1)
+
+        hidden, expanded_edges, expanded_markers = self._expand_views(
+            node_features,
+            edge_index,
+            markers.to(dtype=x.dtype),
+        )
+        for conv in self.convs:
+            marked_hidden = torch.cat((hidden, expanded_markers), dim=-1)
+            update = torch.relu(conv(marked_hidden, expanded_edges))
+            update = self.dropout_layer(update)
+            hidden = hidden + update if self.residual else update
+
+        view_embeddings = hidden.reshape(
+            self.num_samples,
+            x.size(0),
+            self.hidden_channels,
+        )
+        if self.sample_aggregation == "mean":
+            return view_embeddings.mean(dim=0)
+        return view_embeddings.sum(dim=0)


### PR DESCRIPTION
## Description

This PR implements the paper [Balancing Efficiency and Expressiveness: Subgraph GNNs with Walk-Based Centrality](https://proceedings.mlr.press/v267/southern25a.html) by Southern et al. for the TDL 2026 Challenge. HyMN uses walk-based centrality scores for both the subgraph selection policy and the structural encoding inputs, increasing the expressiveness of the subgraph GNN without sacrificing efficiency by considering only the top-ranked nodes.

In this implementation, truncated centrality structural encodings are computed from closed walks of lengths 1–16. The two highest-centrality nodes define marked graph views, which are processed alongside the original unmarked graph by shared residual GIN layers. The resulting node representations are aggregated across views and passed to TopoBench’s task-specific readout, supporting both community detection and triangle counting.

## Tests

- Added focused unit tests for centrality encodings, marked-node selection, view aggregation, batching, caching, permutation equivariance, gradients, and configuration validation.
- Added `graph/hymn` to the required smoke-test coverage.
- Verified linting, formatting, focused unit tests, and pipeline smoke-test execution.

## Checklist

- [x] Clear and explanatory pull request title
- [x] Ruff lint and formatting checks pass
- [x] Focused unit tests and the pipeline smoke test pass
- [x] PEP8-compliant implementation with NumPy-style documentation
